### PR TITLE
Fix startup error entities.map is not a function

### DIFF
--- a/frontend/src/components/Overview/index.tsx
+++ b/frontend/src/components/Overview/index.tsx
@@ -54,8 +54,8 @@ const Overview: StatelessComponent<IOverviewProps> = ({
   null;
 
 const pickLoading = R.propOr(false, 'loading');
-const pickCount = R.pathOr(0, ['nodeQuery', 'count']);
-const pickEntities = R.pathOr(0, ['nodeQuery', 'entities']);
+const pickCount = R.pathOr([], ['nodeQuery', 'count']);
+const pickEntities = R.pathOr([], ['nodeQuery', 'entities']);
 
 export interface IOverviewQueryProps {
   page: number;
@@ -102,7 +102,7 @@ const withQuery = graphql<
 const pickPage = R.compose(
   Math.abs,
   R.flip(R.curryN(2, parseInt))(10),
-  R.pathOr(0, ['url', 'query', 'page'])
+  R.pathOr([], ['url', 'query', 'page'])
 );
 
 const withPagination = withPropsOnChange(['url'], props => ({


### PR DESCRIPTION
## Bug fix:
- When starting this up for the first time no entities exist and the frontend throws the following error:
```
entities.map is not a function
```

## Notes:
- This error only happens when there is no backend or no entities exist on the backend